### PR TITLE
Fix imports, fix path from GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Goland files
+.idea/

--- a/examples/HelloWorld/README.md
+++ b/examples/HelloWorld/README.md
@@ -28,10 +28,9 @@ type Suite struct {
 }
 
 func (s *Suite) SetupSuite() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/HelloWorld")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/HelloWorld")
 	r := s.Runner(dir)
 	r.Run(`echo "Hello world!"`)
 }
-func (s *Suite) Test() {
-}
+func (s *Suite) Test() {}
 ```

--- a/examples/Producer/Consumer1/README.md
+++ b/examples/Producer/Consumer1/README.md
@@ -29,11 +29,12 @@ type Suite struct {
 }
 
 func (s *Suite) SetupSuite() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Producer/Consumer1")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Producer/Consumer1")
 	r := s.Runner(dir)
+
 	r.Run(`echo "I'm the first consumer"`)
 }
-func (s *Suite) Test() {
-}
+
+func (s *Suite) Test() {}
 ```
 Note: the result has not producer setup/teardown logic because this Consumer is used by [Consumer3](../Consumer3) that contains required dependency.

--- a/examples/Producer/Consumer2/README.md
+++ b/examples/Producer/Consumer2/README.md
@@ -33,9 +33,12 @@ type Suite struct {
 
 func (s *Suite) SetupSuite() {
 	suite.Run(s.T(), &s.producerSuite)
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Producer/Consumer2")
+
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Producer/Consumer2")
 	r := s.Runner(dir)
+
 	r.Run(`echo "I'm the second consumer"`)
 }
+
 func (s *Suite) Test() {}
 ```

--- a/examples/Producer/Consumer3/README.md
+++ b/examples/Producer/Consumer3/README.md
@@ -39,10 +39,12 @@ type Suite struct {
 func (s *Suite) SetupSuite() {
 	suite.Run(s.T(), &s.producerSuite)
 	suite.Run(s.T(), &s.consumer1Suite)
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Producer/Consumer3")
+
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Producer/Consumer3")
 	r := s.Runner(dir)
+
 	r.Run(`echo "I'm the third consumer"`)
 }
-func (s *Suite) Test() {}
 
+func (s *Suite) Test() {}
 ```

--- a/examples/Producer/README.md
+++ b/examples/Producer/README.md
@@ -35,12 +35,15 @@ type Suite struct {
 }
 
 func (s *Suite) SetupSuite() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Producer")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Producer")
 	r := s.Runner(dir)
+
 	s.T().Cleanup(func() {
 		r.Run(`echo "Do teardown logic for the suite here"`)
 	})
+
 	r.Run(`echo "Do setup logic for the suite here"`)
 }
+
 func (s *Suite) Test() {}
 ```

--- a/examples/Tree/LeafA/README.md
+++ b/examples/Tree/LeafA/README.md
@@ -14,9 +14,9 @@ The generated result of this example is:
 
 ```go
 func (s *Suite) TestLeafA() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafA")
-    r := s.Runner(dir)    
-	
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafA")
+	r := s.Runner(dir)
+
 	r.Run(`echo "I'm leaf A"`)
 }
 ```

--- a/examples/Tree/LeafC/README.md
+++ b/examples/Tree/LeafC/README.md
@@ -15,8 +15,9 @@ The result of generating a suite from this file will be:
 
 ```go
 func (s *Suite) TestLeafC() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafC")
-    r := s.Runner(dir)    
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafC")
+	r := s.Runner(dir)
+
 	r.Run(`echo "I'm leaf C"`)
 }
 ```

--- a/examples/Tree/README.md
+++ b/examples/Tree/README.md
@@ -49,37 +49,39 @@ import (
 	"path/filepath"
 
 	"github.com/networkservicemesh/gotestmd/pkg/suites/shell"
+	"github.com/networkservicemesh/gotestmd/test-examples/tree/subtree"
+	"github.com/stretchr/testify/suite"
 )
 
 type Suite struct {
 	shell.Suite
+	subtreeSuite subtree.Suite
 }
 
 func (s *Suite) SetupSuite() {
-	s.Suite.SetupSuite()
+	suite.Run(s.T(), &s.subtreeSuite)
 
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree")
 	r := s.Runner(dir)
+
 	s.T().Cleanup(func() {
 		r.Run(`rm -rf ${MY_TEST_DIR}`)
-
 	})
-	r.Run(`MY_TEST_DIR=resources 
-echo "mkdir ${MY_TEST_DIR}"`)
+
+	r.Run(`MY_TEST_DIR=resources ` + "\n" + `echo "mkdir ${MY_TEST_DIR}"`)
 }
 
 func (s *Suite) TestLeafA() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafA")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafA")
 	r := s.Runner(dir)
 
 	r.Run(`echo "I'm leaf A"`)
 }
 
 func (s *Suite) TestLeafC() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafC")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree/LeafC")
 	r := s.Runner(dir)
 
 	r.Run(`echo "I'm leaf C"`)
 }
-
 ```

--- a/examples/Tree/SubTree/LeafB/README.md
+++ b/examples/Tree/SubTree/LeafB/README.md
@@ -14,9 +14,9 @@ The result of generating a suite from this file will be:
 
 ```go
 func (s *Suite) TestLeafB() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/SubTree/LeafB")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree/SubTree/LeafB")
 	r := s.Runner(dir)
+
 	r.Run(`echo "I'm leaf B"`)
 }
-
 ```

--- a/examples/Tree/SubTree/README.md
+++ b/examples/Tree/SubTree/README.md
@@ -30,28 +30,27 @@ import (
 	"path/filepath"
 
 	"github.com/networkservicemesh/gotestmd/pkg/suites/shell"
-	"github.com/networkservicemesh/gotestmd/test-examples/tree"
 )
 
 type Suite struct {
 	shell.Suite
-	treeSuite tree.Suite
 }
 
 func (s *Suite) SetupSuite() {
-	s.Suite.SetupSuite()
-	s.treeSuite.Suite = s.Suite
-	s.treeSuite.SetupSuite()
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/SubTree")
-    r := s.Runner(dir)
+	dir := filepath.Join(os.Getenv("GOPATH"), "/github.com/networkservicemesh/gotestmd/examples/Tree/SubTree")
+	r := s.Runner(dir)
+
+	s.T().Cleanup(func() {
+		r.Run(`echo "Sub tree is done"`)
+	})
 
 	r.Run(`echo "I'm sub tree"`)
 }
 
 func (s *Suite) TestLeafB() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "/github.com/networkservicemesh/gotestmd/examples/Tree/SubTree/LeafB")
+	dir := filepath.Join(os.Getenv("GOPATH"), "/Users/user/Projects/NSM/gotestmd/examples/Tree/SubTree/LeafB")
 	r := s.Runner(dir)
 
-    r.Run(`echo "I'm leaf B"`)
+	r.Run(`echo "I'm leaf B"`)
 }
 ```

--- a/main_test.go
+++ b/main_test.go
@@ -29,8 +29,12 @@ func TestExamples(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.RemoveAll("test-examples/")
 	})
+
 	var bash shell.Bash
+	bash.Env = append(bash.Env, os.Environ()...)
+	bash.Env = append(bash.Env, "GOPACKAGE=github.com/networkservicemesh/gotestmd")
 	defer bash.Close()
+
 	_, err := bash.Run("go install ./...")
 	require.NoError(t, err)
 
@@ -41,6 +45,8 @@ func TestExamples(t *testing.T) {
 package suites
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/networkservicemesh/gotestmd/test-examples/helloworld"
@@ -51,6 +57,11 @@ import (
 )
 
 func TestEntryPoint(t *testing.T) {
+	wd, _ := os.Getwd()
+	if !strings.HasPrefix(wd, os.Getenv("GOPATH")) {
+		_ = os.Setenv("GOPATH", "")
+	}
+
 	suite.Run(t, new(helloworld.Suite))
 	suite.Run(t, new(tree.Suite))
 	suite.Run(t, new(consumer2.Suite))
@@ -60,6 +71,6 @@ EOF
 `)
 	require.NoError(t, err)
 
-	_, err = bash.Run("go test ./test-examples/... ")
+	_, err = bash.Run("go test ./test-examples/...")
 	require.NoError(t, err)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -38,7 +38,7 @@ func TestExamples(t *testing.T) {
 	_, err := bash.Run("go install ./...")
 	require.NoError(t, err)
 
-	_, err = bash.Run("gotestmd examples/ test-examples/")
+	_, err = bash.Run("gotestmd ./examples ./test-examples github.com/networkservicemesh/gotestmd/test-examples")
 	require.NoError(t, err)
 
 	_, err = bash.Run(`cat > test-examples/entry_point_test.go <<EOF

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,36 +19,50 @@ package config
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 )
 
-// Config contains input dir with .md examples and output dir for generated suites
+// Config contains input dir with .md examples, output dir and root package for generated suites
 type Config struct {
-	InputDir  string
-	OutputDir string
+	InputDir    string
+	OutputDir   string
+	RootPackage string
 }
 
 // FromArgs returns Config from the os.Args
 func FromArgs() Config {
-	if len(os.Args) != 3 {
-		logrus.Fatal("ARGs have wrong length. Expected: input-dir output-dir")
+	if len(os.Args) != 3 && len(os.Args) != 4 {
+		logrus.Fatal("ARGs have wrong length. Expected: input-dir output-dir [root-package]")
 	}
 
 	inputDir, _ := filepath.Abs(os.Args[1])
 	if _, err := os.Open(filepath.Clean(inputDir)); err != nil {
-		logrus.Fatalf("An error during checking dir: %v, error: %v", inputDir, err.Error())
+		logrus.Fatalf("An error during checking dir: %v, error: %v", os.Args[1], err.Error())
 	}
-	if _, err := os.Open(filepath.Clean(os.Args[2])); err != nil {
-		err = os.MkdirAll(filepath.Clean(os.Args[2]), os.ModePerm)
+
+	absOutputDir, _ := filepath.Abs(os.Args[2])
+	if _, err := os.Open(filepath.Clean(absOutputDir)); err != nil {
+		err = os.MkdirAll(filepath.Clean(absOutputDir), os.ModePerm)
 		if err != nil {
 			logrus.Fatalf("An error during creating dir: %v, error: %v", os.Args[2], err.Error())
 		}
 	}
-	outputDir, _ := filepath.Abs(os.Args[2])
+
+	var rootPackage string
+	if len(os.Args) == 4 {
+		rootPackage = os.Args[3]
+	} else {
+		wd, _ := os.Getwd()
+		relOutputDir, _ := filepath.Rel(wd, absOutputDir)
+		rootPackage = path.Join(os.Getenv("GOPACKAGE"), filepath.ToSlash(relOutputDir))
+	}
+
 	return Config{
-		InputDir:  inputDir,
-		OutputDir: outputDir,
+		InputDir:    inputDir,
+		OutputDir:   absOutputDir,
+		RootPackage: rootPackage,
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -34,8 +33,8 @@ type Config struct {
 
 // FromArgs returns Config from the os.Args
 func FromArgs() Config {
-	if len(os.Args) != 3 && len(os.Args) != 4 {
-		logrus.Fatal("ARGs have wrong length. Expected: input-dir output-dir [root-package]")
+	if len(os.Args) != 4 {
+		logrus.Fatal("ARGs have wrong length. Expected: input-dir output-dir root-package")
 	}
 
 	inputDir, _ := filepath.Abs(os.Args[1])
@@ -51,18 +50,9 @@ func FromArgs() Config {
 		}
 	}
 
-	var rootPackage string
-	if len(os.Args) == 4 {
-		rootPackage = os.Args[3]
-	} else {
-		wd, _ := os.Getwd()
-		relOutputDir, _ := filepath.Rel(wd, absOutputDir)
-		rootPackage = path.Join(os.Getenv("GOPACKAGE"), filepath.ToSlash(relOutputDir))
-	}
-
 	return Config{
 		InputDir:    inputDir,
 		OutputDir:   absOutputDir,
-		RootPackage: rootPackage,
+		RootPackage: os.Args[3],
 	}
 }

--- a/pkg/example/example.go
+++ b/pkg/example/example.go
@@ -65,7 +65,7 @@ func (e *Example) IsLeaf() bool {
 	return len(e.Childs) == 0 && len(e.Requires) == 0 && len(e.Parents) > 0
 }
 
-// Dependencies returns unique dependecies for this example
+// Dependencies returns unique dependencies for this example
 func (e *Example) Dependencies() []string {
 	var deps []string
 	var parentDeps []string

--- a/pkg/templates/dependencies.go
+++ b/pkg/templates/dependencies.go
@@ -17,7 +17,7 @@
 package templates
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -31,7 +31,7 @@ func (d Dependency) Pkg() string {
 
 // Name returns pkg name
 func (d Dependency) Name() string {
-	_, name := filepath.Split(d.Pkg())
+	_, name := path.Split(d.Pkg())
 	return normalizeName(name)
 }
 

--- a/pkg/templates/suite.go
+++ b/pkg/templates/suite.go
@@ -39,8 +39,8 @@ type Suite struct {
 
 func (s *Suite) SetupSuite() {
 	{{ SETUP }}
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "{{ DIR }}")
-    r := s.Runner(dir)                                                                                                                                                                                                                                                                                                                                   
+	dir := filepath.Join(os.Getenv("GOPATH"), "{{ DIR }}")
+	r := s.Runner(dir)
 	{{ CLEANUP }}
 	{{ RUN }}
 }

--- a/pkg/templates/test.go
+++ b/pkg/templates/test.go
@@ -25,8 +25,8 @@ const emptyTest = `func (s *Suite) Test() {}`
 
 const testTemplate = `
 func (s *Suite) Test{{ NAME }}() {
-	dir := filepath.Join(os.Getenv("GOPATH"), "src", "{{ DIR }}")
-    r := s.Runner(dir)    
+	dir := filepath.Join(os.Getenv("GOPATH"), "{{ DIR }}")
+	r := s.Runner(dir)
 	{{ CLEANUP }}
 	{{ RUN }}
 }


### PR DESCRIPTION
# Issues
1. Imports are generated incorrectly if `inputDirectory` is not located under the `$GOPATH/src`.
2. Path for the bash runner is generated incorrectly if `inputDirectory` is not located under the `$GOPATH/src`.
3. Package names are generated using `filepath` - it is incorrect for the `\` file systems.
# Solution
1. Add `rootPackage` required parameter.
2. Generate path trimming `$GOPATH` prefix.
3. Generate package names using `path`.