### PR TITLE
Support comments in bash scripts

### DIFF
--- a/examples/HelloWorld/README.md
+++ b/examples/HelloWorld/README.md
@@ -7,6 +7,7 @@ The file will include only one test because this example doesn't depend on other
 ## Run
 
 ```bash
+# Hello world!
 echo "Hello world!"
 ```
 
@@ -37,7 +38,7 @@ func (s *Suite) SetupSuite() {
 		}
 	}
 	r := s.Runner("examples/HelloWorld")
-	r.Run(`echo "Hello world!"`)
+	r.Run(`# Hello world!` + "\n" + `echo "Hello world!"`)
 }
 func (s *Suite) Test() {}
 ```

--- a/examples/HelloWorld/README.md
+++ b/examples/HelloWorld/README.md
@@ -11,6 +11,13 @@ The file will include only one test because this example doesn't depend on other
 echo "Hello world!"
 ```
 
+## Cleanup
+
+```bash
+# Good bye
+echo "Good bye!"
+```
+
 # Results
 
 The result of generating a suite is:
@@ -38,6 +45,9 @@ func (s *Suite) SetupSuite() {
 		}
 	}
 	r := s.Runner("examples/HelloWorld")
+	s.T().Cleanup(func() {
+		r.Run(`# Good bye` + "\n" + `echo "Good bye!"`)
+	})
 	r.Run(`# Hello world!` + "\n" + `echo "Hello world!"`)
 }
 func (s *Suite) Test() {}


### PR DESCRIPTION
# Issue
Currently comments in bash scripts sections are not supported because parser parses comment start `#` as a section end.
# Solution
Skip ` ``` ` blocks while searching for the section end.