### PR TITLE
Update go to 1.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Setup envs
         run: |
           echo GOPATH=$GITHUB_WORKSPACE >> $GITHUB_ENV
@@ -53,11 +53,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.35
+          version: v1.45.2
 
   excludeFmtErrorf:
     name: exclude fmt.Errorf
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - run: go mod tidy
       - name: Check for changes in go.mod or go.sum
         run: |

--- a/.github/workflows/update-dependent-repositories.yaml
+++ b/.github/workflows/update-dependent-repositories.yaml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Setup envs
         run: |
           echo GOPATH=$GITHUB_WORKSPACE >> $GITHUB_ENV

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,8 +10,9 @@ linters-settings:
     values:
       regexp:
         company: .*
-        copyright-holder: Copyright \(c\) ({{year-range}}) {{company}}\n\n
-        copyright-holders: ({{copyright-holder}})+
+        copyright-holder-curr: Copyright \(c\) ({{year-range}}) {{company}}\n\n
+        copyright-holder: Copyright \(c\) .*\n\n
+        copyright-holders: ({{copyright-holder}})*({{copyright-holder-curr}})+({{copyright-holder}})*
   errcheck:
     check-type-assertions: false
     check-blank: false
@@ -24,7 +25,7 @@ linters-settings:
           - (github.com/sirupsen/logrus.FieldLogger).Warnf
           - (github.com/sirupsen/logrus.FieldLogger).Errorf
           - (github.com/sirupsen/logrus.FieldLogger).Fatalf
-  golint:
+  revive:
     min-confidence: 0.8
   goimports:
     local-prefixes: github.com/networkservicemesh
@@ -143,7 +144,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
@@ -152,7 +153,7 @@ linters:
     # - lll
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck
@@ -166,3 +167,12 @@ issues:
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - path: internal/generator/generator.go
+      linters:
+        - staticcheck
+      text: "SA1019: strings.Title is deprecated"
+    - path: internal/generator/suite.go
+      linters:
+        - staticcheck
+      text: "SA1019: strings.Title is deprecated"

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,19 @@
 module github.com/networkservicemesh/gotestmd
 
-go 1.16
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/goleak v1.1.10
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	golang.org/x/tools v0.0.0-20191108193012-7d206e10da11 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/pkg/suites/shell/suite_test.go
+++ b/pkg/suites/shell/suite_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -40,7 +42,7 @@ func TestShellFirstTry(t *testing.T) {
 	fileName := "TestShellFirstTry.file"
 
 	r.Run("echo " + fileContent + " >" + fileName)
-	bytes, err := os.ReadFile(filepath.Join(tempDir, fileName))
+	bytes, err := os.ReadFile(filepath.Clean(filepath.Join(tempDir, fileName)))
 	require.NoError(t, err)
 	require.Equal(t, fileContent+"\n", string(bytes))
 }
@@ -63,7 +65,7 @@ func TestShellEventually(t *testing.T) {
 	echo >&2 not enough ones
 	false
 fi`)
-	bytes, err := os.ReadFile(filepath.Join(tempDir, fileName))
+	bytes, err := os.ReadFile(filepath.Clean(filepath.Join(tempDir, fileName)))
 	require.NoError(t, err)
 	require.Equal(t, "1\n11\n111\n", string(bytes))
 }


### PR DESCRIPTION
https://github.com/networkservicemesh/sdk/issues/1264

<!-- * Update Dockerfiles to use `go:1.18-bullseye` instead of `go:1.16-buster`. -->
* In GitHub workflow yamls, update go to 1.18 and golangci-lint to 1.45.2.
* Update `go.mod` files to use `go 1.18`.
* Replace deprecated linters: `golint` -> `revive`, `scopelint` -> exportloopref`.
* Fix `goheader` linting rule configuration.
* Fix linter issues introduced by the new golangci-lint version.