### PR TITLE
Use suite package Run function instead of struct method

### DIFF
--- a/examples/Tree/README.md
+++ b/examples/Tree/README.md
@@ -75,9 +75,7 @@ func (s *Suite) SetupSuite() {
 }
 func (s *Suite) RunIncludedSuites() {
 	s.Run("SubTree", func() {
-		s.subtreeSuite.SetT(s.T())
-		s.subtreeSuite.SetupSuite()
-		s.subtreeSuite.Run("TestLeafB", s.subtreeSuite.TestLeafB)
+		suite.Run(s.T(), &s.subtreeSuite)
 	})
 }
 func (s *Suite) TestLeafA() {


### PR DESCRIPTION
### Description
`testify` has two different Run functions - [one](https://github.com/stretchr/testify/blob/v1.7.5/suite/suite.go#L86) and [two](https://github.com/stretchr/testify/blob/v1.7.5/suite/suite.go#L97).

The second in better because it uses the correct order of the `AfterTest` and `Cleanup` function calls

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>