### PR TITLE
Add retry to generated bash scripts

### DIFF
--- a/examples/Retry/README.md
+++ b/examples/Retry/README.md
@@ -1,0 +1,27 @@
+
+# Retry Example
+
+This file has commands that fail on the first run.
+
+Generated tests will still succeed because commands are retried until timeout.
+
+## Run
+
+```bash
+rm -f retry-file-flag
+```
+
+```bash
+[ -f retry-file-flag ] || (
+cat << EOF > retry-file-flag
+this file must exist before command runs
+EOF
+false
+)
+```
+
+## Cleanup
+
+```bash
+rm retry-file-flag
+```

--- a/examples/Retry/README.md
+++ b/examples/Retry/README.md
@@ -20,6 +20,12 @@ false
 )
 ```
 
+```bash
+cat << EOF
+We also need to make sure that retry does not affect commands which use "<<EOF"
+EOF
+```
+
 ## Cleanup
 
 ```bash

--- a/examples/Tree/README.md
+++ b/examples/Tree/README.md
@@ -28,6 +28,11 @@ MY_TEST_DIR=resources
 echo "mkdir ${MY_TEST_DIR}"
 ```
 
+```bash
+cat << EOF
+We also need to make sure that commands which use "<<EOF" are working without issues.
+EOF
+```
 
 ## Cleanup
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -57,7 +57,7 @@ func (g *Generator) Generate(examples ...*linker.LinkedExample) []*Suite {
 			for _, parent := range e.Parents {
 				tests[parent.Name] = append(tests[parent.Name], &Test{
 					Dir:     e.Dir,
-					Name:    cases.Title(language.AmericanEnglish).String(nameRegex.ReplaceAllString(name, "_")),
+					Name:    cases.Title(language.Und, cases.NoLower).String(nameRegex.ReplaceAllString(name, "_")),
 					Cleanup: e.Cleanup,
 					Run:     e.Run,
 				})

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -265,7 +265,7 @@ function try_run() {
         attempt=$((attempt + 1))
         echo "===== attempt $attempt ====="
         echo "current time $(date +"%Y-%m-%dT%H:%M:%S%z")"
-        source <(echo "${command}")
+        source /dev/stdin <<<"$(echo "${command}")"
         retval=$?
 		echo
         echo "retval = $retval"

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -149,7 +149,7 @@ func (s *Suite) generateChildrenTesting() string {
 	var suites []*suiteData
 	for _, child := range s.Children {
 		_, title := path.Split(child.Dir)
-		title = cases.Title(language.AmericanEnglish).String(nameRegex.ReplaceAllString(title, "_"))
+		title = cases.Title(language.Und, cases.NoLower).String(nameRegex.ReplaceAllString(title, "_"))
 		suite := &suiteData{
 			Title: title,
 			Name:  child.Name(),

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -111,10 +111,10 @@ func (b Body) BashString(withExit, retry bool) string {
 		} else {
 			sb.WriteString(block)
 		}
-		if withExit {
-			sb.WriteString(" || exit")
-		}
 		sb.WriteString("\n")
+		if withExit {
+			sb.WriteString("\t[ $? = 0 ] || exit 1\n")
+		}
 	}
 
 	return sb.String()

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -103,17 +103,12 @@ func (b Body) BashString(withExit bool) string {
 	}
 
 	for _, block := range b {
-		var lines = strings.Split(block, "\n")
 		sb.WriteString("\t")
-		sb.WriteString(lines[0])
-		for i := 1; i < len(lines); i++ {
-			sb.WriteString(" &&\n\t")
-			sb.WriteString(lines[i])
-		}
-		if withExit {
-			sb.WriteString(" || exit")
-		}
+		sb.WriteString(block)
 		sb.WriteString("\n")
+		if withExit {
+			sb.WriteString("\t[ $? = 0 ] || exit\n")
+		}
 	}
 
 	return sb.String()

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -106,7 +106,7 @@ func (b Body) BashString(withExit bool) string {
 		sb.WriteString("\t")
 		if withExit {
 			sb.WriteString("try_run '")
-			sb.WriteString(strings.Replace(block, "'", "'\\''", -1))
+			sb.WriteString(strings.ReplaceAll(block, "'", "'\\''"))
 			sb.WriteString("' || exit")
 		} else {
 			sb.WriteString(block)

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -293,6 +293,7 @@ func (s *Suite) BashString(retry bool) string {
 	absDir, _ := filepath.Abs(s.Dir)
 	s.Run = append([]string{"cd " + absDir}, s.Run...)
 	s.Run = append([]string{fmt.Sprintf("echo 'setup suite %s'", filepath.Dir(s.Location))}, s.Run...)
+	s.Cleanup = append([]string{"cd " + absDir}, s.Cleanup...)
 	s.Cleanup = append([]string{fmt.Sprintf("echo 'cleanup suite %s'", filepath.Dir(s.Location))}, s.Cleanup...)
 
 	tmpl, err := template.New("test").Parse(bashSuiteTemplate)
@@ -343,7 +344,8 @@ func (s *Suite) getDependenciesSetup() []string {
 }
 
 func (s *Suite) getDependenciesCleanup() []string {
-	cleanup := []string{fmt.Sprintf("echo 'cleanup suite %s'", filepath.Dir(s.Location))}
+	absDir, _ := filepath.Abs(s.Dir)
+	cleanup := []string{fmt.Sprintf("echo 'cleanup suite %s'", filepath.Dir(s.Location)), "cd " + absDir}
 	cleanup = append(cleanup, s.Cleanup...)
 	for _, p := range s.Parents {
 		cleanup = append(cleanup, p.getDependenciesSetup()...)

--- a/internal/generator/suite.go
+++ b/internal/generator/suite.go
@@ -231,13 +231,18 @@ setup() {
 }
 
 cleanup_dependencies() {
-{{ .CleanupDependencies }}}
+{{ .CleanupDependencies }}	# cleanup shouldn't report errors
+	true
+}
 
 cleanup_main() {
-{{ .CleanupMain }}}
+{{ .CleanupMain }}	# cleanup shouldn't report errors
+	true
+}
 
 cleanup() {
-	cleanup_main && cleanup_dependencies
+	cleanup_main
+	cleanup_dependencies
 }
 `
 

--- a/internal/generator/test.go
+++ b/internal/generator/test.go
@@ -88,7 +88,7 @@ test{{ .Name }}() {
 {{ .Cleanup }}}`
 
 // BashString generates a bash script for the test
-func (t *Test) BashString() string {
+func (t *Test) BashString(retry bool) string {
 	tmpl, err := template.New("bashtest").Parse(bashTestTemplate)
 	if err != nil {
 		panic(err.Error())
@@ -106,8 +106,8 @@ func (t *Test) BashString() string {
 	}{
 		Name:    t.Name,
 		Dir:     absDir,
-		Run:     t.Run.BashString(true),
-		Cleanup: t.Cleanup.BashString(false),
+		Run:     t.Run.BashString(true, retry),
+		Cleanup: t.Cleanup.BashString(false, false),
 	})
 
 	return result.String()

--- a/main_test.go
+++ b/main_test.go
@@ -147,7 +147,7 @@ func TestBashRetry(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, exitCode)
 
-	// retry package should succees when retry is enabled
+	// retry package should succeed when retry is enabled
 	_, _, exitCode, err = runner.Run("gotestmd examples/ test-bash-examples/ --bash --match=retry --retry")
 	require.NoError(t, err)
 	require.Zero(t, exitCode)

--- a/main_test.go
+++ b/main_test.go
@@ -134,7 +134,7 @@ func TestBashRetry(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, exitCode)
 
-	// chech that retry package fails without retry
+	// check that retry package fails without retry
 	_, _, exitCode, err = runner.Run("gotestmd examples/ test-bash-examples/ --bash --match=retry")
 	require.NoError(t, err)
 	require.Zero(t, exitCode)


### PR DESCRIPTION
Fix bash script generation for multi-line commands.
Add retry function into bash scripts when `--retry` argument is specified.
Run all setup and test commands through retry function.
Fix cleanup.

Issue:
- https://github.com/networkservicemesh/gotestmd/issues/39